### PR TITLE
support build and run on Mac M1 chip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,31 @@
 SHELL:=/usr/bin/env sh
 
+OSFLAG := ""
+UNAME := $(shell uname -m)
+ifeq ($(UNAME), arm64)
+  OSFLAG = DOCKER_DEFAULT_PLATFORM=linux/amd64
+endif
+
 # Build bsc binary docker
 .PHONY:build-bsc
 build-bsc:
-	docker-compose -f docker-compose.bsc.yml build
-
+	$(OSFLAG) docker-compose -f docker-compose.bsc.yml build
 
 # Build & start simple validator cluster
 
 .PHONY:build-simple
 build-simple:
 	make build-bsc
-	docker-compose -f docker-compose.simple.bootstrap.yml build
-	docker-compose -f docker-compose.simple.yml build
+	$(OSFLAG) docker-compose -f docker-compose.simple.bootstrap.yml build
+	$(OSFLAG) docker-compose -f docker-compose.simple.yml build
 
 .PHONY:bootstrap-simple
 bootstrap-simple:
-	docker-compose -f docker-compose.simple.bootstrap.yml run bootstrap-simple
+	$(OSFLAG) docker-compose -f docker-compose.simple.bootstrap.yml run bootstrap-simple
 
 .PHONY:start-simple
 start-simple:
-	docker-compose -f docker-compose.simple.yml up -d bsc-rpc bsc-validator1 netstats
+	$(OSFLAG) docker-compose -f docker-compose.simple.yml up -d bsc-rpc bsc-validator1 netstats
 
 .PHONY:run-test-simple
 run-test-simple:
@@ -31,16 +36,16 @@ run-test-simple:
 .PHONY:build-cluster
 build-cluster:
 	make build-bsc
-	docker-compose -f docker-compose.cluster.bootstrap.yml build
-	docker-compose -f docker-compose.cluster.yml build
+	$(OSFLAG) docker-compose -f docker-compose.cluster.bootstrap.yml build
+	$(OSFLAG) docker-compose -f docker-compose.cluster.yml build
 
 .PHONY:bootstrap-cluster
 bootstrap-cluster:
-	docker-compose -f docker-compose.cluster.bootstrap.yml run bootstrap-cluster
+	$(OSFLAG) docker-compose -f docker-compose.cluster.bootstrap.yml run bootstrap-cluster
 
 .PHONY:start-cluster
 start-cluster:
-	docker-compose -f docker-compose.cluster.yml up -d cluster-bsc-rpc cluster-bsc-validator1 cluster-bsc-validator2 cluster-bsc-validator3 netstats
+	$(OSFLAG) docker-compose -f docker-compose.cluster.yml up -d cluster-bsc-rpc cluster-bsc-validator1 cluster-bsc-validator2 cluster-bsc-validator3 netstats
 
 .PHONY:run-test-cluster
 run-test-cluster:


### PR DESCRIPTION
Issue: error when run bootstrap
`/root/scripts/bootstrap.sh: line 18: /usr/local/bin/geth: No such file or directory`
Update:
- Determine M1 Chip then add `DOCKER_DEFAULT_PLATFORM=linux/amd64` when build and run docker
