### PR TITLE
fix: Dockerfile

### DIFF
--- a/Dockerfile.bsc
+++ b/Dockerfile.bsc
@@ -1,11 +1,10 @@
-FROM golang:1.16-alpine
+FROM golang:1.20.4
 
 ARG GIT_SOURCE
 ARG GIT_CHECKOUT_REF
 
-RUN apk add --no-cache make gcc musl-dev linux-headers git
+RUN apt update && apt install make gcc libc-dev binutils-gold musl-dev git build-essential -y
 
-# Checkout latest version on Feb 8th 2021
 RUN cd / && git clone ${GIT_SOURCE} \
     && cd ./bsc && git checkout ${GIT_CHECKOUT_REF} && make geth
 


### PR DESCRIPTION
- Update Golang image from 1.16-alpine to 1.20.4
- Convert APK to APT due to changing image from alpine
- Add build-essential to fix gcc errors
- Remove extra comment
- Tested on MacOS 13 - MacBook M2 Pro